### PR TITLE
Add reentrancy guards to telnetd_poll and websocketd_poll

### DIFF
--- a/telnetd.c
+++ b/telnetd.c
@@ -530,7 +530,14 @@ void telnet_stream_handler (sessiondata_t *session)
 
 void telnetd_poll (void)
 {
+    static bool in_poll = false;
+
+    if(in_poll)
+        return;  // Prevent reentrancy from stream_tx_blocking callback
+
+    in_poll = true;
     telnet_stream_handler(&streamSession);
+    in_poll = false;
 }
 
 // Deprecated - remove

--- a/websocketd.c
+++ b/websocketd.c
@@ -1368,6 +1368,13 @@ static void websocket_stream_handler (ws_sessiondata_t *session)
 //
 void websocketd_poll (void)
 {
+    static bool in_poll = false;
+
+    if(in_poll)
+        return;  // Prevent reentrancy from stream_tx_blocking callback
+
+    in_poll = true;
+
     ws_sessiondata_t *client;
     uint_fast16_t idx = WEBUI_MAX_CLIENTS;
 
@@ -1380,6 +1387,8 @@ void websocketd_poll (void)
         } else if(client->state == WsState_Closing)
             websocket_close_conn(client, client->pcb);
     } while(idx);
+
+    in_poll = false;
 }
 
 void websocketd_notify_link_status (bool up)


### PR DESCRIPTION
Prevents recursive calls when stream_tx_blocking callback triggers enet_poll during high-frequency status polling (e.g., 50ms intervals).

Without this guard, TX buffer saturation causes cascading blocking that can exhaust resources and hang the connection after extended idle periods.