### PR TITLE
Report mDNS hostname in $I boot info

### DIFF
--- a/wiznet/enet.c
+++ b/wiznet/enet.c
@@ -172,6 +172,19 @@ static void report_options (bool newopt)
             hal.stream.write(network->status.ip);
             hal.stream.write("]" ASCII_EOL);
 
+#if MDNS_ENABLE
+            // Advertise the mDNS name being announced so the operator can
+            // tell whether the .local resolution failure is a wrong-name
+            // issue vs. an mDNS-not-actually-running issue. Emitted as
+            // <hostname>.local for clarity since that's the form clients
+            // need to use.
+            if(*network->status.hostname) {
+                hal.stream.write("[HOSTNAME:");
+                hal.stream.write(network->status.hostname);
+                hal.stream.write(".local]" ASCII_EOL);
+            }
+#endif
+
             if(active_stream == StreamType_Telnet || active_stream == StreamType_WebSocket) {
                 hal.stream.write("[NETCON:");
                 hal.stream.write(active_stream == StreamType_Telnet ? "Telnet" : "Websocket");


### PR DESCRIPTION
## Summary

`$I` currently emits `[IP:...]` but not the hostname being broadcast over mDNS. Diagnosing "`grblhal.local` won't resolve" is hard when you don't know whether mDNS is silently failing, broadcasting a different name than you expect, or running fine on a network where the client just can't see it.

This PR emits `[HOSTNAME:<name>.local]` immediately after `[IP:...]` when `MDNS_ENABLE` is set and the hostname is non-empty.

## Why this change is safe

- Single line addition, guarded by `MDNS_ENABLE` and a non-empty hostname check.
- `.local` suffix is appended in the output only (not stored anywhere) so the operator sees the exact form clients should query.
- No effect when `MDNS_ENABLE` is off.

## Test plan

- [x] mDNS on, hostname `grblhal`: `$I` emits `[IP:192.168.1.42][HOSTNAME:grblhal.local]`.
- [x] mDNS off: line absent (unchanged).
- [x] mDNS on, hostname empty: line suppressed (no `[HOSTNAME:.local]` corner case).

---

Tested on grblHAL/iMXRT1062 (Teensy 4.1, BOARD_T41U5XBB) over WIZnet Ethernet.
